### PR TITLE
Fixed Hits Always Visible

### DIFF
--- a/lua/notagain/jrpg/autorun/hitmarks.lua
+++ b/lua/notagain/jrpg/autorun/hitmarks.lua
@@ -468,8 +468,10 @@ if CLIENT then
 				elseif data.dmg > 0 then
 					txt = "+" .. txt
 				end
+					
+				local tr = IsValid(data.ent) and data.ent:EyePos():Distance((util.TraceLine({start = EyePos(), endpos = data.ent:EyePos()})).HitPos) < 100
 
-				if pos.visible then
+				if pos.visible and tr then
 
 					local x = pos.x + data.pos.x
 					local y = pos.y + data.pos.y


### PR DESCRIPTION
I found it strange that the hit numbers were visible through walls and pretty much gave you an unintentional wallhack. 

I'm not sure if this is intentional but I've added a simple trace to check if LocalPlayer can actually see the Hit Entity.

I know it's probably not the best code and that it probably shouldn't be all in one line, but it's the best I can do at 4AM with a headache.