### PR TITLE
Add spawn check for props.

### DIFF
--- a/lua/notagain/pac_server/autorun/sanitize_prop_spawn.lua
+++ b/lua/notagain/pac_server/autorun/sanitize_prop_spawn.lua
@@ -1,0 +1,45 @@
+if SERVER then 
+
+	util.AddNetworkString("SanitizeSpawn")
+	
+	local sanitizeCvar = CreateConVar("sanitize_prop_spawn", "1", bit.bor(FCVAR_ARCHIVE, FCVAR_REPLICATED), "Prevents spawning props at a blocked area.")
+	
+	-- NOTE: We add a slight offset so stacking will remain functional.
+	local stackingOffset = Vector(0, 0, 0.01)
+	
+	local function CheckSpawnedObject(ply, mdl, ent)
+		
+		local trace = 
+		{ 
+			start = ent:GetPos() + stackingOffset, 
+			endpos = ent:GetPos() + stackingOffset, 
+			filter = ent,
+		}
+
+		local tr = util.TraceEntity( trace, ent )		
+		return tr.Hit
+		
+	end
+
+	hook.Add("PlayerSpawnedProp", "SanitizeSpawn", function(ply, mdl, ent)
+
+		if sanitizeCvar:GetBool() == false then 
+			return 
+		end 
+			
+		if CheckSpawnedObject(ply, mdl, ent) == true then 
+			ent:Remove()
+			net.Start("SanitizeSpawn")
+			net.Send(ply)
+		end 
+		
+	end)	
+	
+else 
+
+	net.Receive("SanitizeSpawn", function(len)
+		notification.AddLegacy( "Bad placement position", NOTIFY_ERROR, 3 )
+		surface.PlaySound( "buttons/button10.wav" )
+	end)
+	
+end 


### PR DESCRIPTION
This will prevent players from spawning objects inside the world or any other blocked area such as spawned objects. Can be turned off with "sanitize_prop_spawn 0"
NOTE: This is using util.TraceEntity which is not considering the object angles, so depending on its rotation it might give false positives or actually allows it to be spawned inside a wall or object.

