### PR TITLE
Prevent SH spam from causing errors

### DIFF
--- a/lua/notagain/goluwa/libraries/client/common_audio.lua
+++ b/lua/notagain/goluwa/libraries/client/common_audio.lua
@@ -15,10 +15,12 @@ do
 	end
 
 	function META:ExecuteEventQueue()
-		for i, data in ipairs(self.event_queue) do
-			self:OnEvent(data.event, data.val)
+		if self.event_queue then --Fix SH errors
+			for i, data in ipairs(self.event_queue) do
+				self:OnEvent(data.event, data.val)
+			end
+			self.event_queue = nil
 		end
-		self.event_queue = nil
 	end
 
 	function META:SetSoundObject(obj)


### PR DESCRIPTION
>[ERROR] notagain/goluwa/libraries/client/common_audio.lua:18: bad argument #1 to 'ipairs' (table expected, got nil)

Happened whenever someone spammed "sh" in chat or through saysound, should be fixed with this.